### PR TITLE
security: update log4j to 2.15

### DIFF
--- a/point-of-sale-app/api-server/pom.xml
+++ b/point-of-sale-app/api-server/pom.xml
@@ -47,10 +47,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-log4j2</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.abm-edge</groupId>
       <artifactId>service-sdk</artifactId>
       <version>0.1.0-SNAPSHOT</version>

--- a/point-of-sale-app/inventory/pom.xml
+++ b/point-of-sale-app/inventory/pom.xml
@@ -48,10 +48,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-log4j2</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.abm-edge</groupId>
       <artifactId>service-sdk</artifactId>
       <version>0.1.0-SNAPSHOT</version>

--- a/point-of-sale-app/payments/pom.xml
+++ b/point-of-sale-app/payments/pom.xml
@@ -48,10 +48,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-log4j2</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.abm-edge</groupId>
       <artifactId>service-sdk</artifactId>
       <version>0.1.0-SNAPSHOT</version>

--- a/point-of-sale-app/pom.xml
+++ b/point-of-sale-app/pom.xml
@@ -35,7 +35,7 @@
   <properties>
     <main.basedir>${project.basedir}</main.basedir>
     <build-plugin.jacoco.version>0.8.7</build-plugin.jacoco.version>
-    <log4j.version>2.15.0</log4j.version>
+    <log4j2.version>2.15.0</log4j2.version>
   </properties>
   <modules>
     <module>service-sdk</module>
@@ -67,17 +67,17 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>${log4j.version}</version>
+      <version>${log4j2.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${log4j.version}</version>
+      <version>${log4j2.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-jul</artifactId>
-      <version>${log4j.version}</version>
+      <version>${log4j2.version}</version>
     </dependency>
   </dependencies>
 

--- a/point-of-sale-app/pom.xml
+++ b/point-of-sale-app/pom.xml
@@ -35,6 +35,7 @@
   <properties>
     <main.basedir>${project.basedir}</main.basedir>
     <build-plugin.jacoco.version>0.8.7</build-plugin.jacoco.version>
+    <log4j.version>2.15.0</log4j.version>
   </properties>
   <modules>
     <module>service-sdk</module>
@@ -43,6 +44,42 @@
     <module>inventory</module>
     <module>payments</module>
   </modules>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-log4j2</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-jul</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jul</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+  </dependencies>
 
   <build>
     <pluginManagement>

--- a/point-of-sale-app/service-sdk/pom.xml
+++ b/point-of-sale-app/service-sdk/pom.xml
@@ -16,8 +16,8 @@
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <parent>


### PR DESCRIPTION
### Fixes log4j zero day exploit

### Background
- [Post from springboot](https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot)
- [CVE-2021-44228 Detail](https://nvd.nist.gov/vuln/detail/CVE-2021-44228)