### PR TITLE
security: update log4j to 2.16

### DIFF
--- a/point-of-sale-app/pom.xml
+++ b/point-of-sale-app/pom.xml
@@ -35,7 +35,7 @@
   <properties>
     <main.basedir>${project.basedir}</main.basedir>
     <build-plugin.jacoco.version>0.8.7</build-plugin.jacoco.version>
-    <log4j2.version>2.15.0</log4j2.version>
+    <log4j2.version>2.16.0</log4j2.version>
   </properties>
   <modules>
     <module>service-sdk</module>


### PR DESCRIPTION
### Fixes log4j zero day exploit

### Background
- [Post from springboot](https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot)
- [CVE-2021-44228 Detail](https://nvd.nist.gov/vuln/detail/CVE-2021-44228)

### How to test:
1. Deploy a GKE cluster
2. Ensure that `KUBECONFIG` points to this cluster in your local terminal
3. Update the `skaffold.yaml` file in the `<repo_root>/point-of-sale-app` path

**replace */rotation-week-dec3* with the name of your project**

![image](https://user-images.githubusercontent.com/7249208/146232587-c37866b0-5023-4cea-bcb5-5e530392fb46.png)

4. Update the K8s yaml files inside `<repo_root>/point-of-sale-app/kubernetes-manifests` to point to the above image urls
![image](https://user-images.githubusercontent.com/7249208/146232859-2cc556ab-fa36-4b01-b644-9a48a85e66e6.png)
![image](https://user-images.githubusercontent.com/7249208/146232890-d6aac60b-f8fa-4302-b324-ba798fc815ad.png)
![image](https://user-images.githubusercontent.com/7249208/146232922-02bd8b5a-4281-44ad-9449-cd3ba0033d56.png)

5. Run `skaffold run --default-repo=gcr.io/<PROJECT_NAME>`
6. Create a proxy to the api-server `kubectl port-forward <api-server-pod-name> 8080:8080`
7. Visit: **localhost:8080** and validate if the app works

### Related PRs
- #18