### PR TITLE
security: update log4j to 2.17.0

### DIFF
--- a/point-of-sale-app/pom.xml
+++ b/point-of-sale-app/pom.xml
@@ -35,7 +35,7 @@
   <properties>
     <main.basedir>${project.basedir}</main.basedir>
     <build-plugin.jacoco.version>0.8.7</build-plugin.jacoco.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
   </properties>
   <modules>
     <module>service-sdk</module>


### PR DESCRIPTION
### Fixes log4j zero day exploit


### Background:
As recently reported on [apache.org](https://logging.apache.org/log4j/2.x/security.html)

Apache Log4j2 versions 2.0-alpha1 through 2.16.0 did not protect from uncontrolled recursion from self-referential lookups. When the logging configuration uses a non-default Pattern Layout with a Context Lookup (for example, $${ctx:loginId}), attackers with control over Thread Context Map (MDC) input data can craft malicious input data that contains a recursive lookup, resulting in a StackOverflowError that will terminate the process. This is also known as a DOS (Denial of Service) attack.

So, log4j should be updated from 2.16.0 to 2.17.0 to prevent this security risk.