### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# See https://help.github.com/en/articles/about-code-owners
+# for more info about CODEOWNERS file.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence.
+*                   @GoogleCloudPlatform/anthos-dpe


### PR DESCRIPTION
This PR adds a CODEOWNERS file, designating the `anthos-dpe` as the owner for the repository.