### PR TITLE
Bump log4j to 2.17.1

### DIFF
--- a/point-of-sale-app/pom.xml
+++ b/point-of-sale-app/pom.xml
@@ -35,7 +35,7 @@
   <properties>
     <main.basedir>${project.basedir}</main.basedir>
     <build-plugin.jacoco.version>0.8.7</build-plugin.jacoco.version>
-    <log4j2.version>2.17.0</log4j2.version>
+    <log4j2.version>2.17.1</log4j2.version>
   </properties>
   <modules>
     <module>service-sdk</module>


### PR DESCRIPTION
This PR bumps `log4j` to `2.17.1` to mitigate [CVE-2021-44832](https://logging.apache.org/log4j/2.x/).