### PR TITLE
fix: pin npm version from renovate bump

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,10 @@
     {
       "matchPackageNames": ["vue-toast-notification"],
       "allowedVersions": "<2.0.0"
+    },
+    {
+      "matchPackageNames": ["npm"],
+      "allowedVersions": "<8.2.0"
     }
   ]
 }


### PR DESCRIPTION
## Issue
- Renovate is trying to bump npm version: #52 
- This is conflict with the node version we use

## What did we do here
- Add a package rule in the renovate settings to ensure npm stay at minor version`8.1.x`